### PR TITLE
Stop using official branding

### DIFF
--- a/testing/palemoon/mozconfig
+++ b/testing/palemoon/mozconfig
@@ -1,6 +1,6 @@
 export MOZILLA_OFFICIAL=1
 mk_add_options MOZ_CO_PROJECT=browser
-ac_add_options --enable-official-branding
+#ac_add_options --enable-official-branding #Do not use official branding on this port!
 
 ac_add_options --enable-application=browser
 ac_add_options --enable-chrome-format=omni


### PR DESCRIPTION
You should not be using official branding on this port, because it is not adhering to the branding/redist policy of Pale Moon. This has already been discussed at length with various people wanting to build musl-based versions.

(The patches included in this port go beyond what is exempt from needing permission.)